### PR TITLE
Update ConfigHolder To Read From Properties File

### DIFF
--- a/src/main/java/com/smartsheet/utils/ConfigHolder.java
+++ b/src/main/java/com/smartsheet/utils/ConfigHolder.java
@@ -16,6 +16,10 @@
 **/
 package com.smartsheet.utils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 /**
  * A holder of specific configuration properties for the current application.
  * Any such properties are injected into this holder.
@@ -23,6 +27,8 @@ package com.smartsheet.utils;
 public class ConfigHolder {
 
     private static final ConfigHolder singleton = new ConfigHolder();
+    private static final String DEFAULT_PROPERTY_FILE = "/smartsheet-backup.properties";
+    private Properties properties;
 
     public static ConfigHolder getInstance() {
         return singleton;
@@ -33,6 +39,11 @@ public class ConfigHolder {
 
     private ConfigHolder() {
         // private constructor because this is a singleton helper class, not intended to be instantiated
+        try{
+          loadDefaultPropertyFile();
+        } catch(IOException e){
+          throw new RuntimeException(e);
+        }
     }
 
     public boolean isContinueOnError() {
@@ -41,5 +52,23 @@ public class ConfigHolder {
 
     public void setContinueOnError(boolean continueOnError) {
         this.continueOnError = continueOnError;
+    }
+
+    private void loadDefaultPropertyFile() throws IOException {
+        InputStream inputStream = getClass().getResourceAsStream(DEFAULT_PROPERTY_FILE);
+        properties = new Properties();
+        properties.load(inputStream);
+    }
+
+    public boolean hasProperties() {
+        return !properties.isEmpty();
+    }
+
+    public boolean hasProperty(String key) {
+        return properties.containsKey(key);
+    }
+
+    public Object getProperty(String key) {
+        return properties.get(key);
     }
 }

--- a/src/main/resources/smartsheet-backup.properties
+++ b/src/main/resources/smartsheet-backup.properties
@@ -1,6 +1,7 @@
 accessToken=[access token]
 outputDir=backup/smartsheet-backup
 continueOnError=true
-#zipOutputDir=true
-#downloadThreads=4
-#allDownloadsDoneTimeout=2
+zipOutputDir=zip
+downloadThreads=4
+allDownloadsDoneTimeout=2
+#commentOutProp=I don't exist

--- a/src/main/resources/smartsheet-backup.properties
+++ b/src/main/resources/smartsheet-backup.properties
@@ -1,0 +1,6 @@
+accessToken=[access token]
+outputDir=backup/smartsheet-backup
+continueOnError=true
+#zipOutputDir=true
+#downloadThreads=4
+#allDownloadsDoneTimeout=2

--- a/src/test/java/com/smartsheet/utils/ConfigHolderTest.java
+++ b/src/test/java/com/smartsheet/utils/ConfigHolderTest.java
@@ -1,0 +1,123 @@
+package com.smartsheet.utils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for ConfigHolder class.
+ * @author isim
+ *
+ */
+public class ConfigHolderTest {
+  
+    private static final String DEFAULT_ACCESS_TOKEN = "[access token]";
+    private static final String DEFAULT_BACKUP_FOLDER = "backup/smartsheet-backup";
+    private static final boolean DEFAULT_CONTINUE_ON_ERROR = true;
+    private static final String DEFAULT_ZIP_OUTPUT_FOLDER = "zip";
+    private static final int DEFAULT_NUM_DOWNLOAD_THREADS = 4;
+    private static final int DEFAULT_ALL_DOWNLOADS_TIMEOUT = 2;
+    
+    private ConfigHolder configHolder;
+
+    @Before
+    public void setUp(){
+        configHolder = ConfigHolder.getInstance();
+    }
+    
+    @Test
+    public void testConfigHolder_CanLoadFromPropertiesFile() {
+        Assert.assertTrue(configHolder.hasProperties());
+    }
+
+    @Test
+    public void testConfigHolder_HasAccessTokenProperty(){
+        Assert.assertTrue(configHolder.hasProperty("accessToken"));
+    }
+  
+    @Test
+    public void testConfigHolder_AccessTokenIsCorrect(){
+        String expected = DEFAULT_ACCESS_TOKEN;
+        String actual = configHolder.getProperty("accessToken").toString();
+        Assert.assertEquals(expected, actual);
+    }
+  
+    @Test
+    public void testConfigHolder_HasOutputDirProperty(){
+        Assert.assertTrue(configHolder.hasProperty("outputDir"));
+    }
+    
+    @Test
+    public void testConfigHolder_OutputDirPathIsCorrect(){
+        String expected = DEFAULT_BACKUP_FOLDER;
+        String actual = configHolder.getProperty("outputDir").toString();
+        Assert.assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void testConfigHolder_HasContinueOnErrorProperty(){
+        Assert.assertTrue(configHolder.hasProperty("continueOnError"));
+    }
+  
+    @Test
+    public void testConfigHolder_ContinueOnErrorIsTrue(){
+        boolean expected = DEFAULT_CONTINUE_ON_ERROR;
+        Assert.assertEquals(expected, Boolean.parseBoolean(configHolder.getProperty("continueOnError").toString()));
+    }
+  
+    @Test
+    public void testConfigHolder_HasZipOutputDirProperty(){
+      Assert.assertTrue(configHolder.hasProperty("zipOutputDir"));
+    }
+  
+    @Test
+    public void testConfigHolder_ZipOutputDirPathIsCorrect(){
+        String expected = DEFAULT_ZIP_OUTPUT_FOLDER;
+        String actual = configHolder.getProperty("zipOutputDir").toString();
+        Assert.assertEquals(expected, actual);
+    }
+  
+    @Test
+    public void testConfigHolder_HasDownloadThreadsProperty(){
+        Assert.assertTrue(configHolder.hasProperty("downloadThreads"));
+    }
+    
+    @Test
+    public void testConfigHolder_DownloadThreadIsCorrect(){
+        int expected = DEFAULT_NUM_DOWNLOAD_THREADS;
+        int actual = Integer.parseInt(configHolder.getProperty("downloadThreads").toString());
+        Assert.assertEquals(expected, actual);
+    }
+  
+    @Test
+    public void testConfigHolder_HasAllDownloadTimeoutProperty(){
+        Assert.assertTrue(configHolder.hasProperty("allDownloadsDoneTimeout"));
+    }
+  
+    @Test
+    public void testConfigHolder_AllDownloadTimeoutIsCorrect(){
+        int expected = DEFAULT_ALL_DOWNLOADS_TIMEOUT;
+        int actual = Integer.parseInt(configHolder.getProperty("allDownloadsDoneTimeout").toString());
+        Assert.assertEquals(expected, actual);
+    }
+  
+    @Test
+    public void testConfigHolder_NonExistentProperty_ExpectNotFound(){
+        Assert.assertTrue(!configHolder.hasProperty("unknownProperty"));
+    }
+  
+    @Test
+    public void testConfigHolder_TryGetNonExistentProperty_ExpectNull(){
+        Assert.assertNull(configHolder.getProperty("unknownProperty"));
+    }
+    
+    @Test
+    public void testConfigHolder_CommentOutProperty_ExpectNotFound(){
+        Assert.assertTrue(!configHolder.hasProperty("commentOutProperty"));
+    }
+    
+    @Test
+    public void testConfigHolder_TryGetCommentOutProperty_ExpectNull(){
+        Assert.assertNull(configHolder.getProperty("commentOutProperty"));
+    }
+}


### PR DESCRIPTION
HI,

I have updated the ConfigHolder to read directly from the properties file. This can help to isolate all the file I/O codes from the SmartsheetBackupTool class. Hope this will be helpful.
