### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/src/main/java/com/smartsheet/utils/ConfigHolder.java
+++ b/src/main/java/com/smartsheet/utils/ConfigHolder.java
@@ -20,7 +20,7 @@ package com.smartsheet.utils;
  * A holder of specific configuration properties for the current application.
  * Any such properties are injected into this holder.
  */
-public class ConfigHolder {
+public final class ConfigHolder {
 
     private static final ConfigHolder singleton = new ConfigHolder();
 

--- a/src/main/java/com/smartsheet/utils/ErrorHandler.java
+++ b/src/main/java/com/smartsheet/utils/ErrorHandler.java
@@ -19,7 +19,7 @@ package com.smartsheet.utils;
 /**
  * An application-level error handler.
  */
-public class ErrorHandler {
+public final class ErrorHandler {
 
     private ErrorHandler() {
         // private constructor because this is a singleton helper class, not intended to be instantiated

--- a/src/main/java/com/smartsheet/utils/FileUtils.java
+++ b/src/main/java/com/smartsheet/utils/FileUtils.java
@@ -29,7 +29,7 @@ import com.smartsheet.exceptions.DeleteFileSystemItemException;
 /**
  * Utilities for file operations.
  */
-public class FileUtils {
+public final class FileUtils {
 
     private static final int ZIP_BUFFER_SIZE = 64*1024; // 64K
 

--- a/src/main/java/com/smartsheet/utils/HttpUtils.java
+++ b/src/main/java/com/smartsheet/utils/HttpUtils.java
@@ -42,7 +42,7 @@ import sun.misc.IOUtils;
 /**
  * Utilities for HTTP operations.
  */
-public class HttpUtils {
+public final class HttpUtils {
 
     private static final String CHARSET = "UTF-8";
     private static final String ACCEPT_JSON_HEADER = "application/json; charset=" + CHARSET.toLowerCase();

--- a/src/main/java/com/smartsheet/utils/ProgressWatcher.java
+++ b/src/main/java/com/smartsheet/utils/ProgressWatcher.java
@@ -29,7 +29,7 @@ import java.util.Date;
  * A Progress Watcher which receives status and error notifications, publishing
  * them to the console.
  */
-public class ProgressWatcher {
+public final class ProgressWatcher {
 
     private static final String SMARTSHEET_BACKUP_ERROR_LOG_PREFIX = "smartsheet-backup-error-log_";
     private static final String SMARTSHEET_BACKUP_ERROR_LOG_EXTENSION = ".log";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat