### PR TITLE
Add smartsheetApiBaseUrl as optional application property

### DIFF
--- a/smartsheet-backup.properties
+++ b/smartsheet-backup.properties
@@ -4,3 +4,4 @@ outputDir=backup/smartsheet-backup
 #zipOutputDir=true
 #downloadThreads=4
 #allDownloadsDoneTimeout=2
+#smartsheetApiBaseUrl=https://api.smartsheetgov.com/2.0/

--- a/src/main/java/com/smartsheet/restapi/service/ErrorContextualizingSmartsheetService.java
+++ b/src/main/java/com/smartsheet/restapi/service/ErrorContextualizingSmartsheetService.java
@@ -102,4 +102,9 @@ public class ErrorContextualizingSmartsheetService implements SmartsheetService,
 		ecss.delegateService = (SmartsheetService) this.delegateService.clone();
 		return ecss;
 	}
+
+	@Override
+	public String getApiBaseUrl() {
+		return delegateService.getApiBaseUrl();
+	}
 }

--- a/src/main/java/com/smartsheet/restapi/service/RestfulSmartsheetService.java
+++ b/src/main/java/com/smartsheet/restapi/service/RestfulSmartsheetService.java
@@ -37,13 +37,20 @@ import com.smartsheet.utils.HttpUtils;
  */
 public class RestfulSmartsheetService implements SmartsheetService, Cloneable {
 
-	public static final String API_BASE_URL = "https://api.smartsheet.com/2.0/";
+	public static final String DEFAULT_API_BASE_URL = "https://api.smartsheet.com/2.0/";
+	public final String API_BASE_URL;
 
 	private String accessToken;
 	private String assumedUserEmail;
 
 	public RestfulSmartsheetService(String accessToken) {
 		this.accessToken = accessToken;
+		this.API_BASE_URL = this.DEFAULT_API_BASE_URL;
+	}
+
+	public RestfulSmartsheetService(String accessToken, String apiBaseUrl) {
+		this.accessToken = accessToken;
+		this.API_BASE_URL = apiBaseUrl;
 	}
 
 	@Override
@@ -103,5 +110,10 @@ public class RestfulSmartsheetService implements SmartsheetService, Cloneable {
 		rss.accessToken = this.accessToken;
 
 		return rss;
+	}
+
+	@Override
+	public String getApiBaseUrl() {
+		return this.API_BASE_URL;
 	}
 }

--- a/src/main/java/com/smartsheet/restapi/service/RetryingSmartsheetService.java
+++ b/src/main/java/com/smartsheet/restapi/service/RetryingSmartsheetService.java
@@ -164,4 +164,8 @@ public class RetryingSmartsheetService implements SmartsheetService, Cloneable {
 		return rss;
 	}
 
+	@Override
+	public String getApiBaseUrl() {
+		return delegateService.getApiBaseUrl();
+	}
 }

--- a/src/main/java/com/smartsheet/restapi/service/SmartsheetService.java
+++ b/src/main/java/com/smartsheet/restapi/service/SmartsheetService.java
@@ -42,6 +42,8 @@ public interface SmartsheetService {
     void assumeUser(String assumedUserEmail);
 
     String getAssumedUser();
+
+    String getApiBaseUrl();
     
     public Object clone() throws CloneNotSupportedException;
 }

--- a/src/main/java/com/smartsheet/tools/SheetSaver.java
+++ b/src/main/java/com/smartsheet/tools/SheetSaver.java
@@ -63,7 +63,7 @@ public class SheetSaver {
 	 */
 	public File save(SmartsheetSheet sheet, File folder) throws Exception {
 		File sheetFile = createFileFor(sheet, folder.getAbsolutePath(), XLSX_EXTENSION);
-		String url = RestfulSmartsheetService.API_BASE_URL + "sheets/" + sheet.getId();
+		String url = apiService.getApiBaseUrl() + "sheets/" + sheet.getId();
 		String accessToken = apiService.getAccessToken();
 		String userToAssume = apiService.getAssumedUser();
 		try {

--- a/src/main/java/com/smartsheet/tools/SmartsheetBackupService.java
+++ b/src/main/java/com/smartsheet/tools/SmartsheetBackupService.java
@@ -112,7 +112,7 @@ public class SmartsheetBackupService {
 				// for each active user, assume the identity of the user to
 				// backup that user's sheets in the user's context (e.g., what
 				// sheets they own, the hierarchy they see in Smartsheet, etc.)
-				if (status.equals(USER_ACTIVE_STATUS)) {
+				if (status != null && status.equals(USER_ACTIVE_STATUS)) {
 
 					ProgressWatcher.getInstance()
 							.notify(String.format(
@@ -129,6 +129,7 @@ public class SmartsheetBackupService {
 				} else {
 					// user not active yet and will result in 401 (Unauthorized)
 					// if try to assume their identity, so skip...
+					status = (status != null) ? status : "status unknown";
 					ProgressWatcher.getInstance()
 							.notify(String.format(
 									"--------------------SKIP backup for user [%d of %d]: %s (%s)--------------------",

--- a/src/main/java/com/smartsheet/tools/SmartsheetBackupTool.java
+++ b/src/main/java/com/smartsheet/tools/SmartsheetBackupTool.java
@@ -85,14 +85,19 @@ public class SmartsheetBackupTool {
 			int downloadThreads = getOptionalProp(props, "downloadThreads",
 					DEFAULT_DOWNLOAD_THREADS, 1);
 
+			String apiBaseUrl = getOptionalProp(props, "smartsheetApiBaseUrl");
+
 			// 2. instantiate services
+			RestfulSmartsheetService restfulService = apiBaseUrl == null ?
+					new RestfulSmartsheetService(accessToken) :
+					new RestfulSmartsheetService(accessToken, apiBaseUrl);
 			SmartsheetService apiService = new ErrorContextualizingSmartsheetService(
 			// the ErrorContextualizingSmartsheetService wraps the
 			// RetryingSmartsheetService:
 					new RetryingSmartsheetService(
 					// the RetryingSmartsheetService wraps the
 					// RestfulSmartsheetService:
-							new RestfulSmartsheetService(accessToken)));
+							restfulService));
 
 			ParallelDownloadService parallelDownloadService = new ParallelDownloadService(downloadThreads);
 
@@ -246,5 +251,13 @@ public class SmartsheetBackupTool {
 					+ Boolean.FALSE + "'");
 
 		return Boolean.valueOf(prop);
+	}
+
+	private static String getOptionalProp(Properties props, String propName) {
+		String prop = props.getProperty(propName);
+		if (prop == null || prop.trim().isEmpty())
+			return null;
+
+		return prop;
 	}
 }

--- a/src/test/java/com/smartsheet/tools/test/StubServiceUnavailableSmartsheetService.java
+++ b/src/test/java/com/smartsheet/tools/test/StubServiceUnavailableSmartsheetService.java
@@ -71,4 +71,9 @@ public class StubServiceUnavailableSmartsheetService implements SmartsheetServic
 	public Object clone() throws CloneNotSupportedException {
 		return super.clone();
 	}
+
+	@Override
+	public String getApiBaseUrl() {
+		return null;
+	}
 }

--- a/src/test/java/com/smartsheet/tools/test/StubSmartsheetService.java
+++ b/src/test/java/com/smartsheet/tools/test/StubSmartsheetService.java
@@ -81,4 +81,9 @@ public class StubSmartsheetService implements SmartsheetService {
 	public Object clone() throws CloneNotSupportedException {
     	return super.clone();
     }
+
+    @Override
+    public String getApiBaseUrl() {
+        return null;
+    }
 }


### PR DESCRIPTION
In order to enable use of the backup tool on Smartsheet Gov, I've added smartsheetApiBaseUrl as an option property in the smartsheet-backup.properties file, and replaced direct references to the static string API_BASE_URL with a lookup and member variable.

I also fixed a NullPointerException when the `status` of a user is null.