### PR TITLE
remove oracle lib reference and upgrade to openjdk 11

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -41,8 +41,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>6</source>
-          <target>6</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>6</source>
-                    <target>6</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/smartsheet/utils/HttpUtils.java
+++ b/src/main/java/com/smartsheet/utils/HttpUtils.java
@@ -37,7 +37,6 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import com.smartsheet.exceptions.ServiceUnavailableException;
 import com.smartsheet.restapi.service.RetryingSmartsheetService;
 import com.smartsheet.tools.SmartsheetBackupTool;
-import sun.misc.IOUtils;
 
 /**
  * Utilities for HTTP operations.


### PR DESCRIPTION
- To remove Oracle library reference that is not required
- To increase OpenJDK support to at least 2024 by upgrading to 11